### PR TITLE
Fix supertrend adx indicator bug

### DIFF
--- a/adx_separate.pine
+++ b/adx_separate.pine
@@ -1,0 +1,30 @@
+//@version=5
+indicator("ADX Oscillator", shorttitle="ADX", format=format.price, precision=2)
+
+// === INPUTS ===
+adxPeriod = input.int(14, "ADX Period", minval=1, maxval=50)
+adxThreshold = input.int(24, "ADX Threshold", minval=10, maxval=50)
+
+// === CALCULATIONS ===
+adx = ta.adx(adxPeriod)
+di_plus = ta.dmi(adxPeriod, adxPeriod)[0]
+di_minus = ta.dmi(adxPeriod, adxPeriod)[1]
+
+// === PLOTS ===
+plot(adx, title="ADX", color=color.orange, linewidth=2)
+plot(di_plus, title="DI+", color=color.green, linewidth=1)
+plot(di_minus, title="DI-", color=color.red, linewidth=1)
+
+// Threshold line
+hline(adxThreshold, title="ADX Threshold", color=color.gray, linestyle=hline.style_dashed, linewidth=1)
+
+// Background colors for trend strength
+bgcolor(adx > adxThreshold ? color.new(color.yellow, 90) : na, title="Strong Trend Background")
+
+// Labels for trend strength
+var label strengthLabel = na
+if barstate.islast
+    label.delete(strengthLabel)
+    strengthText = adx > adxThreshold ? "Strong Trend" : "Weak Trend"
+    strengthColor = adx > adxThreshold ? color.green : color.red
+    strengthLabel := label.new(bar_index, adx, strengthText, color=strengthColor, style=label.style_label_left, textcolor=color.white, size=size.small)

--- a/supertrend_adx_fixed.pine
+++ b/supertrend_adx_fixed.pine
@@ -1,0 +1,60 @@
+//@version=5
+indicator("Supertrend with ADX Filter", overlay=true)
+
+// === INPUTS ===
+factor = input.float(3.0, "Supertrend Factor", step=0.1, minval=0.1, maxval=10.0)
+atrPeriod = input.int(10, "ATR Period", minval=1, maxval=50)
+adxPeriod = input.int(14, "ADX Period", minval=1, maxval=50)
+adxThreshold = input.int(24, "ADX Threshold", minval=10, maxval=50)
+
+// === CALCULATIONS ===
+// ATR calculation
+atr = ta.atr(atrPeriod)
+
+// Supertrend calculation
+hl2 = (high + low) / 2
+upperBand = hl2 + factor * atr
+lowerBand = hl2 - factor * atr
+
+var float trendUp = na
+var float trendDown = na
+var int trend = 1
+
+// Proper supertrend logic
+trendUp := na(trendUp[1]) ? lowerBand : (close[1] > trendUp[1] ? math.max(lowerBand, trendUp[1]) : lowerBand)
+trendDown := na(trendDown[1]) ? upperBand : (close[1] < trendDown[1] ? math.min(upperBand, trendDown[1]) : upperBand)
+
+trend := close > trendUp[1] ? 1 : close < trendDown[1] ? -1 : nz(trend[1], 1)
+supertrend = trend == 1 ? trendUp : trendDown
+
+// ADX calculation
+adx = ta.adx(adxPeriod)
+
+// === SIGNAL CONDITIONS ===
+trendChange = trend != trend[1]
+buySignal = trendChange and trend == 1 and adx > adxThreshold
+sellSignal = trendChange and trend == -1 and adx > adxThreshold
+
+// === PLOTS ===
+// Supertrend line
+supertrendColor = trend == 1 ? color.green : color.red
+plot(supertrend, title="Supertrend", color=supertrendColor, linewidth=2)
+
+// Buy/Sell signals
+plotshape(buySignal, title="Buy Signal", location=location.belowbar, color=color.green, style=shape.triangleup, size=size.small, text="BUY")
+plotshape(sellSignal, title="Sell Signal", location=location.abovebar, color=color.red, style=shape.triangledown, size=size.small, text="SELL")
+
+// Background color for trend
+bgcolor(trend == 1 ? color.new(color.green, 95) : color.new(color.red, 95), title="Trend Background")
+
+// === ALERTS ===
+alertcondition(buySignal, title="Supertrend Buy", message="Supertrend Buy Signal - ADX: " + str.tostring(adx, "#.##"))
+alertcondition(sellSignal, title="Supertrend Sell", message="Supertrend Sell Signal - ADX: " + str.tostring(adx, "#.##"))
+
+// === TABLE FOR ADX INFO ===
+if barstate.islast
+    var table infoTable = table.new(position.top_right, 2, 2, bgcolor=color.white, border_width=1)
+    table.cell(infoTable, 0, 0, "ADX", text_color=color.black, text_size=size.small)
+    table.cell(infoTable, 1, 0, str.tostring(adx, "#.##"), text_color=color.black, text_size=size.small)
+    table.cell(infoTable, 0, 1, "Threshold", text_color=color.black, text_size=size.small)
+    table.cell(infoTable, 1, 1, str.tostring(adxThreshold), text_color=color.black, text_size=size.small)

--- a/supertrend_adx_indicator.pine
+++ b/supertrend_adx_indicator.pine
@@ -1,0 +1,52 @@
+//@version=5
+indicator("Supertrend with ADX Filter", overlay=true)
+
+// === INPUTS ===
+factor = input.float(3.0, "Supertrend Factor", step=0.1)
+atrPeriod = input.int(10, "ATR Period")
+adxPeriod = input.int(14, "ADX Period")
+adxThreshold = input.int(24, "ADX Threshold")
+showADX = input.bool(true, "Show ADX in separate pane")
+
+// === CALCULATIONS ===
+// ATR
+atr = ta.atr(atrPeriod)
+
+// Supertrend Logic
+hl2 = (high + low) / 2
+upperBand = hl2 + factor * atr
+lowerBand = hl2 - factor * atr
+
+var float trendUp = na
+var float trendDown = na
+var int trend = 1
+
+// Fixed supertrend calculation with proper initialization
+trendUp := na(trendUp[1]) ? lowerBand : (close[1] > trendUp[1] ? math.max(lowerBand, trendUp[1]) : lowerBand)
+trendDown := na(trendDown[1]) ? upperBand : (close[1] < trendDown[1] ? math.min(upperBand, trendDown[1]) : upperBand)
+
+trend := close > trendUp[1] ? 1 : close < trendDown[1] ? -1 : nz(trend[1], 1)
+
+supertrend = trend == 1 ? trendUp : trendDown
+
+// ADX Calculation
+adx = ta.adx(adxPeriod)
+
+// === CONDITIONS ===
+trendChange = trend != trend[1]
+buySignal = trendChange and trend == 1 and adx > adxThreshold
+sellSignal = trendChange and trend == -1 and adx > adxThreshold
+
+// === PLOTS ===
+plotshape(buySignal, title="Buy Signal", location=location.belowbar, color=color.green, style=shape.triangleup, size=size.small)
+plotshape(sellSignal, title="Sell Signal", location=location.abovebar, color=color.red, style=shape.triangledown, size=size.small)
+
+plot(trend == 1 ? supertrend : na, title="Supertrend Up", color=color.green, linewidth=2)
+plot(trend == -1 ? supertrend : na, title="Supertrend Down", color=color.red, linewidth=2)
+
+// === ADX Plot (conditional display) ===
+plot(showADX ? adx : na, title="ADX", color=color.orange, display=display.data_window)
+
+// Alert conditions
+alertcondition(buySignal, title="Buy Signal", message="Supertrend Buy Signal with ADX > {{plot.adxThreshold}}")
+alertcondition(sellSignal, title="Sell Signal", message="Supertrend Sell Signal with ADX > {{plot.adxThreshold}}")


### PR DESCRIPTION
Refactor Supertrend with ADX indicator into two separate scripts and fix calculation logic to resolve TradingView display and functionality bugs.

The original script had conflicting overlay and pane display modes, and the Supertrend calculation logic was inverted, causing it to malfunction in TradingView. This PR splits the indicator into a Supertrend overlay and a separate ADX pane indicator, correcting the Supertrend calculation and enhancing usability with alerts and an info table.

---
<a href="https://cursor.com/background-agent?bcId=bc-09e3c7f5-3c58-4662-a375-f5b2b0ec1ca7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-09e3c7f5-3c58-4662-a375-f5b2b0ec1ca7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>